### PR TITLE
changes around course name with language

### DIFF
--- a/src/app/(public)/public-bundle-exports/components/NewBundleExportToCanvas.tsx
+++ b/src/app/(public)/public-bundle-exports/components/NewBundleExportToCanvas.tsx
@@ -5,6 +5,7 @@ import { Suspense, useState } from "react"
 import { Prisma } from "@prisma/client"
 
 import CanvasCoursePicker from "./CanvasCoursePicker"
+import { JsonObject } from "@prisma/client/runtime/library";
 
 type BundleExportWithBundle = Prisma.BundleExportGetPayload<{
   include: { bundle: true };
@@ -37,7 +38,7 @@ export default function NewBundleExportToCanvas({bundleExport, startExportWithNe
     }
   }
 
-  const courseName = (bundleExport.bundle.importMetadata as { full_course_name: string }).full_course_name
+  const courseName = (bundleExport.metadata as JsonObject).courseName as string;
 
   return <div>
     <h2>Where should we load {courseName}?</h2>

--- a/src/app/(public)/public-bundle-exports/components/PublicBundleExport.tsx
+++ b/src/app/(public)/public-bundle-exports/components/PublicBundleExport.tsx
@@ -6,6 +6,7 @@ import ExportUpdatesWidget from "./ExportUpdatesWidget";
 import { BundleExportUpdate } from "src/app/jobs/BundleExportUpdate"
 
 import { Prisma } from "@prisma/client"
+import { JsonObject } from '@prisma/client/runtime/library';
 
 type BundleExportWithBundle = Prisma.BundleExportGetPayload<{
   include: { bundle: true };
@@ -72,7 +73,7 @@ export const PublicBundleExport = ({ bundleExport }: PublicBundleExportProps) =>
   return (
     <>
       <div>
-        <h1>Loading {(bundleExport.bundle.importMetadata as { full_course_name: string })!.full_course_name}</h1>
+        <h1>Loading {(bundleExport.metadata as JsonObject).courseName as string}</h1>
 
         <p>
           Status: {exportStateMapping[exportProgress.status]}

--- a/src/app/(public)/public-bundles/components/PublicBundle.tsx
+++ b/src/app/(public)/public-bundles/components/PublicBundle.tsx
@@ -80,7 +80,9 @@ export const PublicBundle = ({ bundleId, language }: PublicBundleProps) => {
   }
 
   const importMetadata = bundle.importMetadata as importMetadata;
-  const courseName = importMetadata.full_course_name;
+
+  const languageDescription = language !== 'en' && languages[language] ? ` [${languages[language]}]` : '';
+  const courseName = importMetadata.full_course_name + languageDescription;
 
   return (
     <>

--- a/src/lib/exporters/CanvasLegacyOpenSciEdExporter.ts
+++ b/src/lib/exporters/CanvasLegacyOpenSciEdExporter.ts
@@ -38,17 +38,16 @@ type Language = 'en' | 'es';
 
 export default class CanvasLegacyOpenSciEdExporter {
   prismaBundleExport: BundleExport;
-
   ocxBundleExportCanvas?: OcxBundleExportCanvas;
-
   courseUrl: string | null = null;
-
   language: Language;
+  courseName: string;
 
   constructor(prismaBundleExport: BundleExport) {
     this.prismaBundleExport = prismaBundleExport;
 
     this.language = (prismaBundleExport.metadata as JsonObject).language as Language || 'en';
+    this.courseName = (prismaBundleExport.metadata as JsonObject).courseName as string || '';
   }
 
   async exportAll(): Promise<string | null> {
@@ -111,7 +110,7 @@ export default class CanvasLegacyOpenSciEdExporter {
       totalActivities: totalActivityNodes
     });
 
-    courseNode.metadata.name = `${(bundle.importMetadata as { full_course_name: string }).full_course_name}`;
+    courseNode.metadata.name = this.courseName;
     const moduleExport = await this.ocxBundleExportCanvas.exportOcxNodeToModule(courseNode, canvasModulePosition);
 
     // iterate on the oer:Unit nodes which represent lesson sets for OpenScied and should not generate any module in Canvas

--- a/src/pages/api/canvas-oauth-export-callback.ts
+++ b/src/pages/api/canvas-oauth-export-callback.ts
@@ -6,6 +6,9 @@ import { randomBytes } from 'crypto';
 import { getOAuth2Token } from "src/lib/exporters/repositories/callCanvas"
 import ExportDestinationService from "src/lib/ExportDestinationService"
 
+import { languages } from "src/constants/languages";
+import { JsonObject } from "@prisma/client/runtime/library";
+
 export default api(async (req, res) => {
   const { code, state } = req.query
 
@@ -54,10 +57,19 @@ export default api(async (req, res) => {
   // create a random token
   const token = randomBytes(32).toString('hex');
 
+  const bundle = await db.bundle.findFirst({
+    where: {
+      id: bundleId,
+    }
+  });
+  const languageDescription = language !== 'en' && languages[language] ? ` [${languages[language]}]` : '';
+  const courseName = (bundle?.importMetadata as JsonObject).full_course_name + languageDescription;
+
   const bundleExport = await db.bundleExport.create({
     data: {
       name: `Temp ${canvasInstance.name} Export`,
       metadata: {
+        courseName: courseName,
         courseCode: "test1",
         language: language || "en",
       },


### PR DESCRIPTION
We have course name only for english language,
whenever it's other language we need add  it
at the end - like when "es" we add "Spanish".