### PR TITLE
add scopes for oauth request

### DIFF
--- a/src/app/(admin)/export-destinations/mutations/generateCanvasOAuth2ExportDestinationUrl.ts
+++ b/src/app/(admin)/export-destinations/mutations/generateCanvasOAuth2ExportDestinationUrl.ts
@@ -1,3 +1,4 @@
+import { oauth2AuthLink } from "@/src/lib/exporters/repositories/callCanvas"
 import { resolver } from "@blitzjs/rpc"
 import db from "db"
 import { z } from "zod"
@@ -29,11 +30,7 @@ export default resolver.pipe(
 
     const state = StateEncoder.encodeState(canvasInstanceId, name, baseUrl)
 
-    const authUrl = `${canvasInstance.baseUrl}/login/oauth2/auth?client_id=${
-      canvasInstance.clientId
-    }&response_type=code&redirect_uri=${encodeURIComponent(
-      `${baseUrl}/api/canvas-oauth-callback`
-    )}&state=${state}`
+    const authUrl = oauth2AuthLink(canvasInstance, state, `${baseUrl}/api/canvas-oauth-callback`)
 
     return authUrl
   }

--- a/src/app/(public)/public-bundles/mutations/getExportRedirectUrl.ts
+++ b/src/app/(public)/public-bundles/mutations/getExportRedirectUrl.ts
@@ -2,6 +2,7 @@ import { resolver } from "@blitzjs/rpc";
 import { ExportBundleSchema } from "../schemas";
 
 import ExportDestinationService from "src/lib/ExportDestinationService"
+import { scopeUrls, oauth2AuthLink } from "@/src/lib/exporters/repositories/callCanvas";
 
 export type ExportRedirectResponse = {
   redirectUrl?: string;
@@ -20,11 +21,7 @@ export default resolver.pipe(
         language: language || "en",
       });
 
-      const authUrl = `${canvasInstance.baseUrl}/login/oauth2/auth?client_id=${
-        canvasInstance.clientId
-      }&response_type=code&redirect_uri=${encodeURIComponent(
-        `${localUrlBase}/api/canvas-oauth-export-callback`
-      )}&state=${state}`
+      const authUrl = oauth2AuthLink(canvasInstance, state, `${localUrlBase}/api/canvas-oauth-export-callback`);
 
       return { redirectUrl: authUrl }
     } else {

--- a/src/lib/exporters/repositories/callCanvas.ts
+++ b/src/lib/exporters/repositories/callCanvas.ts
@@ -30,7 +30,7 @@ export default async function callCanvas(
 ) {
   const url = /^https?:\/\//i.test(path)
     ? path
-    : new URL(`api/v1/${path}?per_page=100`, baseUrl);
+    : new URL(`api/v1/${path}`, baseUrl);
 
   const fetchWithAuthorization = async () => {
     const response = await fetch(url, {
@@ -130,4 +130,40 @@ export async function getOAuth2Token(canvasInstance: CanvasInstance | CanvasInst
       code: code,
     }),
   });
+}
+
+export const scopeUrls = [
+  // Assigments
+  "url:POST|/api/v1/courses/:course_id/assignments",
+  // Content Migrations
+  "url:POST|/api/v1/courses/:course_id/content_migrations",
+  // Courses
+  "url:GET|/api/v1/courses",
+  "url:GET|/api/v1/courses/:id",
+  "url:POST|/api/v1/accounts/:account_id/courses",
+  "url:POST|/api/v1/courses/:course_id/files",
+  // Discussion Topics
+  "url:POST|/api/v1/courses/:course_id/discussion_topics",
+  // Modules
+  "url:POST|/api/v1/courses/:course_id/modules",
+  "url:POST|/api/v1/courses/:course_id/modules/:module_id/items",
+  // Progress
+  "url:GET|/api/v1/progress/:id",
+  // Quiz Questions
+  "url:POST|/api/v1/courses/:course_id/quizzes/:quiz_id/questions",
+  // Quizzes
+  "url:GET|/api/v1/courses/:course_id/quizzes",
+  "url:PUT|/api/v1/courses/:course_id/quizzes/:id",
+]
+
+export function oauth2AuthLink(canvasInstance: CanvasInstance | CanvasInstanceLike, state: string, redirectUrl: string) {
+  return `${canvasInstance.baseUrl}/login/oauth2/auth?client_id=${
+    canvasInstance.clientId
+  }&response_type=code&redirect_uri=${encodeURIComponent(
+    redirectUrl
+  )}&state=${
+    state
+  }&scope=${
+    scopeUrls.join(" ")
+  }`
 }


### PR DESCRIPTION
Clients doesn't want to give us tokens with
permissions for everything. To do that they need to select scopes which we can do. If they do that, canvas requires us to send those scopes to canvas to specify what we are logging in for.