### PR TITLE
Add User Agent to Canvas call in compliance with CISO (Instructure)

### DIFF
--- a/src/constants/canvas.ts
+++ b/src/constants/canvas.ts
@@ -1,0 +1,2 @@
+export const CANVAS_USER_AGENT = 'OCXLoader/1.0.0'
+

--- a/src/lib/ExportDestinationService.ts
+++ b/src/lib/ExportDestinationService.ts
@@ -2,6 +2,7 @@ import { CanvasInstance, ExportDestination } from "@prisma/client"
 
 import db from "db"
 import { JsonObject } from "type-fest"
+import { CANVAS_USER_AGENT } from "../constants/canvas"
 
 export default class ExportDestinationService {
   exportDestination: ExportDestination;
@@ -19,6 +20,7 @@ export default class ExportDestinationService {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "User-Agent": CANVAS_USER_AGENT,
       },
       body: JSON.stringify({
         grant_type: "refresh_token",

--- a/src/lib/exporters/repositories/callCanvas.ts
+++ b/src/lib/exporters/repositories/callCanvas.ts
@@ -1,5 +1,6 @@
 import { CanvasInstance, Prisma } from "@prisma/client"
 import airbrake from "config/airbrake"
+import { CANVAS_USER_AGENT } from "../../../constants/canvas"
 
 export class HttpError extends Error {
   description: string = '';
@@ -39,6 +40,7 @@ export default async function callCanvas(
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
+        'User-Agent': CANVAS_USER_AGENT,
       }
     });
 
@@ -106,6 +108,9 @@ export async function finalizeCanvasFileUpload(fileUploadParams: CanvasFileUploa
 
   return await fetch(fileUploadParams.upload_url, {
     method: 'POST',
+    headers: {
+      'User-Agent': CANVAS_USER_AGENT,
+    },
     body: formData
   });
 }
@@ -121,6 +126,7 @@ export async function getOAuth2Token(canvasInstance: CanvasInstance | CanvasInst
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      'User-Agent': CANVAS_USER_AGENT,
     },
     body: JSON.stringify({
       grant_type: 'authorization_code',

--- a/src/ocx/loader/repositories/callCanvas.ts
+++ b/src/ocx/loader/repositories/callCanvas.ts
@@ -1,4 +1,5 @@
 import { HttpError } from "../types";
+import { CANVAS_USER_AGENT } from "../../../constants/canvas";
 
 export default async function callCanvas(
   baseUrl: string,
@@ -18,6 +19,7 @@ export default async function callCanvas(
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
+        'User-Agent': CANVAS_USER_AGENT,
       }
     });
 


### PR DESCRIPTION
As required by Instructure in the [following](https://community.instructure.com/en/discussion/658205/enforcing-user-agent-header-for-canvas-api-requests/p1) announcement.